### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -89,6 +93,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of NooDS, so it can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing in the core stands in the way: the `unix` branch of `Makefile.libretro` is architecture-neutral (`-fPIC -shared -Wl,--version-script`, no `-m64` or SSE flags anywhere), and `android-arm64-v8a`, `osx-arm64`, `libretro-build-ios-arm64` and the Switch target already build these sources for ARM64.

This adds the `/linux-aarch64.yml` template and one job that mirrors the x64 one:

```yaml
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

`.core-defs` stays last in `extends` so it keeps overriding `MAKEFILE` with `Makefile.libretro`, exactly like the existing Linux jobs.

Verified locally on aarch64 (postmarketOS, glibc, GCC 15): `make -f Makefile.libretro platform=unix` builds clean with no source changes, and the resulting `noods_libretro.so` (ELF 64-bit ARM aarch64) loads in RetroArch 1.22.2 and runs *007: Blood Stone* at ~59 fps, 256x384, on the HLE BIOS — no BIOS files needed.
